### PR TITLE
VP-6514: add GQL.groovy, add smoke test for XDigitalCatalog

### DIFF
--- a/Keywords/services/GQL.groovy
+++ b/Keywords/services/GQL.groovy
@@ -1,0 +1,67 @@
+package services
+import com.kms.katalon.core.annotation.Keyword
+import groovy.json.JsonSlurper
+import internal.GlobalVariable as GlobalVariable
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+
+/**
+ * GraphQL entry point for all requests to GraphQL server.
+ * Contains logic to send requests and verify responses.
+ */
+public class GQL {
+	public String url
+	Response response
+
+	/**
+	 * Default constructor.
+	 */
+	public GQL(String url){
+		this.url = url
+	}
+
+	/**
+	 * Send request to GraphQl server.
+	 */
+	@Keyword
+	def sendRequest(String query){
+		OkHttpClient client = new OkHttpClient()
+		MediaType mediaType = MediaType.parse("application/json")
+		RequestBody body = RequestBody.create(mediaType, query)
+
+		println(query)
+
+		Request request = new Request.Builder()
+				.url(this.url)
+				.post(body)
+				.build()
+		response = client.newCall(request).execute()
+		return response
+	}
+
+	/**
+	 * Check if status code exactly the same of response of GraphQL request.
+	 * Use after sending request.
+	 */
+	@Keyword
+	def verifyStatusCode(int statusCode){
+		assert response.code == statusCode
+	}
+
+	/**
+	 * Check if JSON response of GraphQL request contains proper structure.
+	 * Use after sending request.
+	 */
+	@Keyword
+	def verifyPayloadContainsData(){
+		def responseText = response.body().string()
+		println responseText
+		JsonSlurper parser = new JsonSlurper()
+		def payload = parser.parseText(responseText)
+		assert payload.data != null
+		return payload
+	}
+}

--- a/Profiles/default.glbl
+++ b/Profiles/default.glbl
@@ -179,4 +179,14 @@
       <initValue>''</initValue>
       <name>ffcId</name>
    </GlobalVariableEntity>
+   <GlobalVariableEntity>
+      <description>Default culture name for GraphQL requests</description>
+      <initValue>'en-Us'</initValue>
+      <name>gql_cultureName</name>
+   </GlobalVariableEntity>
+   <GlobalVariableEntity>
+      <description>Default currency code for GraphQL requests</description>
+      <initValue>'USD'</initValue>
+      <name>gql_currencyCode</name>
+   </GlobalVariableEntity>
 </GlobalVariableEntities>

--- a/Scripts/GraphQL Coverage/XDigitalCatalog/SmokeProduct/Script1609157027990.groovy
+++ b/Scripts/GraphQL Coverage/XDigitalCatalog/SmokeProduct/Script1609157027990.groovy
@@ -1,0 +1,6 @@
+import internal.GlobalVariable as GlobalVariable
+import services.GQL as GQL
+
+GQL gql = new GQL(GlovalVariable.urlBack)
+def response = gql.sendRequest("{\"query\":{product(id: \"${GlobalVariable.productId}\", storeId: \"${GlobalVariable.storeId}\", cultureName: \"${GlobalVariable.gql_cultureName}\", currencyCode: \"${GlobalVariable.gql_currencyCode}\"){id}}")
+gql.verifyPayloadContainsData()

--- a/Test Cases/GraphQL Coverage/.meta
+++ b/Test Cases/GraphQL Coverage/.meta
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FolderEntity>
+   <description>folder</description>
+   <name>GraphQL Coverage</name>
+   <tag></tag>
+   <folderType>TESTCASE</folderType>
+</FolderEntity>

--- a/Test Cases/GraphQL Coverage/XDigitalCatalog/SmokeProduct.tc
+++ b/Test Cases/GraphQL Coverage/XDigitalCatalog/SmokeProduct.tc
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description>Default description</description>
+   <name>SmokeProduct</name>
+   <tag></tag>
+   <comment></comment>
+   <testCaseGuid>5aee4472-2ffb-472a-95ed-827f0100b770</testCaseGuid>
+</TestCaseEntity>

--- a/Test Suites/Modules/ExperienceAPI.groovy
+++ b/Test Suites/Modules/ExperienceAPI.groovy
@@ -1,0 +1,66 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.checkpoint.CheckpointFactory as CheckpointFactory
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testcase.TestCaseFactory as TestCaseFactory
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testdata.TestDataFactory as TestDataFactory
+import com.kms.katalon.core.testobject.ObjectRepository as ObjectRepository
+import com.kms.katalon.core.testobject.TestObject as TestObject
+
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+
+import internal.GlobalVariable as GlobalVariable
+
+import com.kms.katalon.core.annotation.SetUp
+import com.kms.katalon.core.annotation.SetupTestCase
+import com.kms.katalon.core.annotation.TearDown
+import com.kms.katalon.core.annotation.TearDownTestCase
+
+/**
+ * Some methods below are samples for using SetUp/TearDown in a test suite.
+ */
+
+/**
+ * Setup test suite environment.
+ */
+@SetUp(skipped = true) // Please change skipped to be false to activate this method.
+def setUp() {
+	// Put your code here.
+}
+
+/**
+ * Clean test suites environment.
+ */
+@TearDown(skipped = true) // Please change skipped to be false to activate this method.
+def tearDown() {
+	// Put your code here.
+}
+
+/**
+ * Run before each test case starts.
+ */
+@SetupTestCase(skipped = true) // Please change skipped to be false to activate this method.
+def setupTestCase() {
+	// Put your code here.
+}
+
+/**
+ * Run after each test case ends.
+ */
+@TearDownTestCase(skipped = true) // Please change skipped to be false to activate this method.
+def tearDownTestCase() {
+	// Put your code here.
+}
+
+/**
+ * References:
+ * Groovy tutorial page: http://docs.groovy-lang.org/next/html/documentation/
+ */

--- a/Test Suites/Modules/ExperienceAPI.ts
+++ b/Test Suites/Modules/ExperienceAPI.ts
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestSuiteEntity>
+   <description>Integration tests for CI/CD</description>
+   <name>ExperienceAPI</name>
+   <tag></tag>
+   <isRerun>false</isRerun>
+   <mailRecipient></mailRecipient>
+   <numberOfRerun>0</numberOfRerun>
+   <pageLoadTimeout>10</pageLoadTimeout>
+   <pageLoadTimeoutDefault>true</pageLoadTimeoutDefault>
+   <rerunFailedTestCasesOnly>false</rerunFailedTestCasesOnly>
+   <rerunImmediately>false</rerunImmediately>
+   <testSuiteGuid>a3ee65f2-65d0-4a98-bc5a-8aafad8c6507</testSuiteGuid>
+   <testCaseLink>
+      <guid>086d06d4-6f06-4c68-8584-10c0ede74e27</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/GraphQL Coverage/XDigitalCatalog/SmokeProduct</testCaseId>
+   </testCaseLink>
+</TestSuiteEntity>

--- a/settings/internal/com.kms.katalon.composer.testcase.properties
+++ b/settings/internal/com.kms.katalon.composer.testcase.properties
@@ -1,2 +1,2 @@
-#Wed Dec 09 18:57:36 MSK 2020
+#Mon Dec 28 14:28:17 EET 2020
 testCaseTag=""


### PR DESCRIPTION
### Problem:
1. No infrastructure for GraphQL requests (only prototype);
2. Zero tests for XApi.

### Solution:
1. Implement GraphQl client for Katalon;
2. Add smoke test for XDigitalCatalog (less expensive);
3. Add some default props to the global variables.

### Jira: 
https://virtocommerce.atlassian.net/browse/VP-6514