### PR TITLE
VP-7507: upload theme archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,6 @@ settings/internal/com.kms.katalon.integration.jira.properties
 settings/internal/com.kms.katalon.testcase.properties
 settings/internal/com.kms.katalon.composer.testcase.properties
 
-/profiles/localProfile.glbl
+/Profiles/localProfile.glbl
+
+.cache/

--- a/Object Repository/API/backWebServices/VirtoCommerce.Content/ContentFileNew.rs
+++ b/Object Repository/API/backWebServices/VirtoCommerce.Content/ContentFileNew.rs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <WebServiceRequestEntity>
    <description></description>
-   <name>DRAFT.ContentFileNew</name>
+   <name>ContentFileNew</name>
    <tag></tag>
    <elementGuidId>bc2251d7-5489-4844-b79f-519852154477</elementGuidId>
    <selectorMethod>BASIC</selectorMethod>
@@ -14,10 +14,10 @@
   &quot;charset&quot;: &quot;UTF-8&quot;,
   &quot;parameters&quot;: [
     {
-      &quot;name&quot;: &quot;filex&quot;,
-      &quot;value&quot;: &quot;D:\\Downloads\\reports.zip&quot;,
+      &quot;name&quot;: &quot;file&quot;,
+      &quot;value&quot;: &quot;TestFiles/theme_test_x.zip&quot;,
       &quot;type&quot;: &quot;File&quot;,
-      &quot;contentType&quot;: &quot;multipart/form-data&quot;
+      &quot;contentType&quot;: &quot;&quot;
     }
   ]
 }</httpBodyContent>
@@ -48,6 +48,13 @@
    <soapServiceFunction></soapServiceFunction>
    <socketTimeout>-1</socketTimeout>
    <useServiceInfoFromWsdl>true</useServiceInfoFromWsdl>
+   <variables>
+      <defaultValue>''</defaultValue>
+      <description></description>
+      <id>83638630-7a88-40ac-be99-b0805a5b2b58</id>
+      <masked>false</masked>
+      <name>folderUrl</name>
+   </variables>
    <verificationScript>import static org.assertj.core.api.Assertions.*
 
 import com.kms.katalon.core.testobject.ResponseObject

--- a/Object Repository/API/backWebServices/VirtoCommerce.Content/ContentGet.rs
+++ b/Object Repository/API/backWebServices/VirtoCommerce.Content/ContentGet.rs
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <WebServiceRequestEntity>
    <description></description>
-   <name>_ContentGet</name>
+   <name>ContentGet</name>
    <tag></tag>
    <elementGuidId>20192eb4-d1a7-43ec-a073-572b730e3bb5</elementGuidId>
    <selectorMethod>BASIC</selectorMethod>
    <useRalativeImagePath>false</useRalativeImagePath>
+   <connectionTimeout>-1</connectionTimeout>
    <followRedirects>false</followRedirects>
    <httpBody></httpBody>
    <httpBodyContent>{
@@ -28,14 +29,25 @@
       <type>Main</type>
       <value>${GlobalVariable.api_key}</value>
    </httpHeaderProperties>
+   <maxResponseSize>-1</maxResponseSize>
    <migratedVersion>5.4.1</migratedVersion>
    <restRequestMethod>GET</restRequestMethod>
-   <restUrl>${GlobalVariable.urlBack}/api/content/${GlobalVariable.contentType}/${GlobalVariable.storeId}?relativeUrl=qweblog/qweblog.md</restUrl>
+   <restUrl>${GlobalVariable.urlBack}/api/content/${GlobalVariable.contentType}/${GlobalVariable.storeId}?relativeUrl=${relativeUrl}</restUrl>
    <serviceType>RESTful</serviceType>
    <soapBody></soapBody>
    <soapHeader></soapHeader>
    <soapRequestMethod></soapRequestMethod>
+   <soapServiceEndpoint></soapServiceEndpoint>
    <soapServiceFunction></soapServiceFunction>
+   <socketTimeout>-1</socketTimeout>
+   <useServiceInfoFromWsdl>true</useServiceInfoFromWsdl>
+   <variables>
+      <defaultValue>'/theme_test_x/theme_test.html'</defaultValue>
+      <description></description>
+      <id>c87a4da2-a306-4cc8-8386-dd6494061e20</id>
+      <masked>false</masked>
+      <name>relativeUrl</name>
+   </variables>
    <verificationScript>import static org.assertj.core.api.Assertions.*
 
 import com.kms.katalon.core.testobject.ResponseObject

--- a/Object Repository/API/backWebServices/VirtoCommerce.Content/ContentUnpack.rs
+++ b/Object Repository/API/backWebServices/VirtoCommerce.Content/ContentUnpack.rs
@@ -9,14 +9,18 @@
    <connectionTimeout>-1</connectionTimeout>
    <followRedirects>false</followRedirects>
    <httpBody></httpBody>
-   <httpBodyContent></httpBodyContent>
-   <httpBodyType></httpBodyType>
+   <httpBodyContent>{
+  &quot;contentType&quot;: &quot;application/x-www-form-urlencoded&quot;,
+  &quot;charset&quot;: &quot;UTF-8&quot;,
+  &quot;parameters&quot;: []
+}</httpBodyContent>
+   <httpBodyType>x-www-form-urlencoded</httpBodyType>
    <httpHeaderProperties>
       <isSelected>true</isSelected>
       <matchCondition>equals</matchCondition>
       <name>Content-Type</name>
       <type>Main</type>
-      <value>multipart/form-data</value>
+      <value>application/x-www-form-urlencoded</value>
    </httpHeaderProperties>
    <httpHeaderProperties>
       <isSelected>true</isSelected>
@@ -28,7 +32,7 @@
    <maxResponseSize>-1</maxResponseSize>
    <migratedVersion>5.4.1</migratedVersion>
    <restRequestMethod>GET</restRequestMethod>
-   <restUrl>${GlobalVariable.urlBack}/api/content/${GlobalVariable.contentType}/${GlobalVariable.storeId}/unpack?archivepath=reports.zip&amp;destPath=reports1</restUrl>
+   <restUrl>${GlobalVariable.urlBack}/api/content/${GlobalVariable.contentType}/${GlobalVariable.storeId}/unpack?archivepath=${archivePath}&amp;destPath=${folderUrl}</restUrl>
    <serviceType>RESTful</serviceType>
    <soapBody></soapBody>
    <soapHeader></soapHeader>
@@ -37,6 +41,13 @@
    <soapServiceFunction></soapServiceFunction>
    <socketTimeout>-1</socketTimeout>
    <useServiceInfoFromWsdl>true</useServiceInfoFromWsdl>
+   <variables>
+      <defaultValue>''</defaultValue>
+      <description></description>
+      <id>6b079739-e3c1-45d8-a1e1-6f933d9e2bb2</id>
+      <masked>false</masked>
+      <name>folderUrl</name>
+   </variables>
    <verificationScript>import static org.assertj.core.api.Assertions.*
 
 import com.kms.katalon.core.testobject.ResponseObject
@@ -47,7 +58,7 @@ import com.kms.katalon.core.util.KeywordUtil
 
 ResponseObject response = WSResponseManager.getInstance().getCurrentResponse()
 KeywordUtil.logInfo(response.responseBodyContent)
-WS.verifyResponseStatusCode(response, 200)
+WS.verifyResponseStatusCode(response, 204)
 </verificationScript>
    <wsdlAddress></wsdlAddress>
 </WebServiceRequestEntity>

--- a/Scripts/API Coverage/CMS_module/moduleContent_themeUpload/Script1625478749754.groovy
+++ b/Scripts/API Coverage/CMS_module/moduleContent_themeUpload/Script1625478749754.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.comment('TEST CASE: Theme. Upload file from local')
+
+GlobalVariable.contentType = "themes"
+
+//Upload .zip file to the platform to unpack it in the further steps
+uploadFileUrlLocal = WS.sendRequestAndVerify(findTestObject('API/backWebServices/VirtoCommerce.Content/ContentFileNew'))
+
+//Get uploaded archive path 
+archivePath = WS.getElementPropertyValue(uploadFileUrlLocal, '[0].url')
+
+//Unpack the archive to its current location directory
+unpackArchive = WS.sendRequestAndVerify(findTestObject('API/backWebServices/virtoCommerce.Content/ContentUnpack', [
+	('folderUrl') : 'theme_test_x' , ('archivePath') : archivePath
+	]))
+
+//Verify that the archive was successfully unpacked and unpacked file exists
+unpackedHtmlFile = WS.sendRequestAndVerify(findTestObject('API/backWebservices/virtoCommerce.Content/ContentGet', [
+	('relativeUrl') : '/theme_test_x/theme_test.html'
+	]))
+

--- a/Test Cases/API Coverage/CMS_module/moduleContent_themeUpload.tc
+++ b/Test Cases/API Coverage/CMS_module/moduleContent_themeUpload.tc
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description>Upload and unpack theme.zip</description>
+   <name>moduleContent_themeUpload</name>
+   <tag></tag>
+   <comment></comment>
+   <testCaseGuid>a1b31d73-d2bd-40f8-a981-c712b4634e41</testCaseGuid>
+</TestCaseEntity>


### PR DESCRIPTION
> This pull request adds a test case at VirtoCommerce.Content
![Screenshot at Jul 06 13-45-24](https://user-images.githubusercontent.com/60473236/124587816-bd5ac000-de60-11eb-8b9b-f33095d39862.png)

> The test case consequently 
1. uploads an archive
2. gets p.1 archive path
3. unpacks the archive 
4. confirms that files from the archive exist where they're supposed to

> The following backWebServiceApi objects were configured for the purposes of this test case:
![Screenshot at Jul 06 14-08-44](https://user-images.githubusercontent.com/60473236/124590345-b1bcc880-de63-11eb-9b67-bcc9df84446c.png)
> ContentFileNew - uploads an archive (* "DRAFT." tag has been removed from the beginnig of the name)
> ContentUnpack - unpacks the uploaded archive 
> ContentGet - searches for content by url (* "_" tag has been removed from the beginning of the name)

> As a result of launching this test case you will see the uploaded html file 
![Screenshot at Jul 06 14-26-05](https://user-images.githubusercontent.com/60473236/124592430-1ed15d80-de66-11eb-836b-a6435259a816.png)

